### PR TITLE
Improve secondary button styling for light mode

### DIFF
--- a/app/client/src/styles/global.css
+++ b/app/client/src/styles/global.css
@@ -54,20 +54,41 @@ button {
 }
 
 .secondary-button {
-  background: transparent;
+  background: #f3f4f6;
+  color: #1f2933;
   border: 1px solid #d1d5db;
   border-radius: 8px;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   font-size: 0.95rem;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .secondary-button:hover:not(:disabled) {
   background: #e5e7eb;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+.secondary-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .secondary-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .secondary-button {
+    background: #1f2937;
+    color: #e5e7eb;
+    border-color: #374151;
+  }
+
+  .secondary-button:hover:not(:disabled) {
+    background: #111827;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  }
 }


### PR DESCRIPTION
## Summary
- give secondary buttons an opaque light background and clearer hover state so they remain visible in light mode
- add focus-visible styling and dark mode adjustments to maintain accessibility and contrast

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df1e6777288332985f33e005125c14