### PR TITLE
Enable editing for saved exercises and past workout days

### DIFF
--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -11,6 +11,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/p/:profileId" element={<Profile />} />
         <Route path="/p/:profileId/workout/today" element={<TodayWorkout />} />
+        <Route path="/p/:profileId/workout/:sessionDate" element={<TodayWorkout />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/app/client/src/components/ExerciseCard.css
+++ b/app/client/src/components/ExerciseCard.css
@@ -16,6 +16,18 @@
   gap: 1.25rem;
 }
 
+.exercise-card-actions {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.exercise-card-actions .primary-button,
+.exercise-card-actions .secondary-button {
+  white-space: nowrap;
+}
+
 .exercise-card-header h2 {
   margin: 0;
 }

--- a/app/client/src/components/ExerciseCard.tsx
+++ b/app/client/src/components/ExerciseCard.tsx
@@ -20,12 +20,15 @@ export interface SessionExercise {
 
 interface ExerciseCardProps {
   exercise: SessionExercise;
+  locked: boolean;
   onSetChange: (setId: number, payload: { actual_reps: number | null; actual_weight: number | null }) => void;
   onSkip: (exerciseId: number) => void;
+  onSave: (exerciseId: number) => void;
+  onEdit: (exerciseId: number) => void;
 }
 
-export function ExerciseCard({ exercise, onSetChange, onSkip }: ExerciseCardProps) {
-  const disabled = exercise.skipped === 1;
+export function ExerciseCard({ exercise, locked, onSetChange, onSkip, onSave, onEdit }: ExerciseCardProps) {
+  const disabled = exercise.skipped === 1 || locked;
   const target = `${exercise.targetSets} × ${exercise.repLow}-${exercise.repHigh}`;
 
   return (
@@ -37,9 +40,22 @@ export function ExerciseCard({ exercise, onSetChange, onSkip }: ExerciseCardProp
             {target} {exercise.targetWeight ? `@ ${exercise.targetWeight} lb` : ''}
           </p>
         </div>
-        <button className="secondary-button" type="button" onClick={() => onSkip(exercise.id)} disabled={disabled}>
-          Skip Exercise
-        </button>
+        <div className="exercise-card-actions">
+          {disabled ? (
+            <button className="secondary-button" type="button" onClick={() => onEdit(exercise.id)}>
+              Edit
+            </button>
+          ) : (
+            <>
+              <button className="secondary-button" type="button" onClick={() => onSkip(exercise.id)}>
+                Skip Exercise
+              </button>
+              <button className="primary-button" type="button" onClick={() => onSave(exercise.id)}>
+                Save
+              </button>
+            </>
+          )}
+        </div>
       </div>
       <div className="exercise-set-list">
         {exercise.sets.map((set) => (

--- a/app/client/src/components/WeekGrid.css
+++ b/app/client/src/components/WeekGrid.css
@@ -15,6 +15,24 @@
   box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.45);
 }
 
+.week-grid-cell--clickable {
+  cursor: pointer;
+  border: none;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  color: inherit;
+}
+
+.week-grid-cell--clickable:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 44px -26px rgba(37, 99, 235, 0.35);
+}
+
+.week-grid-cell--clickable:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.65);
+  outline-offset: 3px;
+}
+
 .week-grid-cell h3 {
   margin: 0;
   font-size: 1rem;
@@ -59,6 +77,14 @@
     background: rgba(15, 23, 42, 0.78);
     border-color: rgba(148, 163, 184, 0.22);
     box-shadow: 0 20px 40px -26px rgba(14, 116, 144, 0.55);
+  }
+
+  .week-grid-cell--clickable:hover {
+    box-shadow: 0 26px 46px -24px rgba(59, 130, 246, 0.45);
+  }
+
+  .week-grid-cell--clickable:focus-visible {
+    outline-color: rgba(96, 165, 250, 0.65);
   }
 
   .week-grid-cell h3,

--- a/app/client/src/components/WeekGrid.tsx
+++ b/app/client/src/components/WeekGrid.tsx
@@ -19,6 +19,7 @@ export interface PlanDay {
 interface WeekGridProps {
   weekStart: string;
   days: PlanDay[];
+  onSelectDay?: (date: string) => void;
 }
 
 function formatTarget(exercise: PlanExercise) {
@@ -30,7 +31,7 @@ function formatTarget(exercise: PlanExercise) {
   return sets;
 }
 
-export function WeekGrid({ weekStart, days }: WeekGridProps) {
+export function WeekGrid({ weekStart, days, onSelectDay }: WeekGridProps) {
   const start = dayjs(weekStart);
   const ordered = [1, 2, 3, 4, 5, 6, 0].map((dow) => days.find((d) => d.dayOfWeek === dow));
 
@@ -38,8 +39,9 @@ export function WeekGrid({ weekStart, days }: WeekGridProps) {
     <div className="week-grid">
       {ordered.map((day, idx) => {
         const date = start.add(idx, 'day');
-        return (
-          <div key={idx} className="week-grid-cell card">
+        const dateString = date.format('YYYY-MM-DD');
+        const content = (
+          <>
             <h3>{date.format('ddd MMM D')}</h3>
             <p className="week-grid-title">{day?.title ?? 'Rest'}</p>
             <div className="week-grid-body">
@@ -56,6 +58,25 @@ export function WeekGrid({ weekStart, days }: WeekGridProps) {
                 <div className="rest-day">Rest / Recovery</div>
               )}
             </div>
+          </>
+        );
+
+        if (onSelectDay) {
+          return (
+            <button
+              key={idx}
+              type="button"
+              className="week-grid-cell card week-grid-cell--clickable"
+              onClick={() => onSelectDay(dateString)}
+              aria-label={`Edit workout for ${date.format('dddd, MMM D')}`}
+            >
+              {content}
+            </button>
+          );
+        }
+        return (
+          <div key={idx} className="week-grid-cell card">
+            {content}
           </div>
         );
       })}

--- a/app/client/src/pages/Profile.tsx
+++ b/app/client/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import dayjs from 'dayjs';
 import WeekGrid, { PlanDay } from '../components/WeekGrid';
 import Tabs from '../components/Tabs';
@@ -35,6 +35,7 @@ function mondayOfWeek(date: dayjs.Dayjs) {
 
 function Profile() {
   const { profileId } = useParams();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<'plan' | 'stats'>('plan');
   const [weekStart, setWeekStart] = useState(() => mondayOfWeek(dayjs()).format('YYYY-MM-DD'));
   const [plan, setPlan] = useState<PlanResponse | null>(null);
@@ -178,7 +179,13 @@ function Profile() {
           <div className="panel-body">
             {planLoading && <p>Loading plan…</p>}
             {planError && <p className="error">{planError}</p>}
-            {plan && <WeekGrid weekStart={weekStart} days={plan.days} />}
+            {plan && (
+              <WeekGrid
+                weekStart={weekStart}
+                days={plan.days}
+                onSelectDay={(date) => navigate(`/p/${profileId}/workout/${date}`)}
+              />
+            )}
           </div>
         </section>
       ) : (

--- a/app/server/src/routes/sessions.js
+++ b/app/server/src/routes/sessions.js
@@ -176,6 +176,20 @@ router.patch('/session-exercises/:id/skip', async (req, res, next) => {
   }
 });
 
+router.patch('/session-exercises/:id/unskip', async (req, res, next) => {
+  const id = parseInt(req.params.id, 10);
+  if (!id) {
+    return res.status(400).json({ error: 'Invalid id' });
+  }
+  try {
+    const pool = getPool();
+    await pool.query('UPDATE session_exercises SET skipped=0 WHERE id=?', [id]);
+    res.json({ id, skipped: false });
+  } catch (error) {
+    next(error);
+  }
+});
+
 router.put('/set-entries/:id', async (req, res, next) => {
   const id = parseInt(req.params.id, 10);
   if (!id) {


### PR DESCRIPTION
## Summary
- add save/edit controls to exercise cards so sets can be locked and reopened after skipping or saving
- allow selecting any day from the weekly grid to open the workout editor for that date
- add an API endpoint to unskip session exercises when returning to edit them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df2457ada0833296f4043939d1b286